### PR TITLE
Update DD-WRT and Astrill

### DIFF
--- a/DD-WRT and Astrill
+++ b/DD-WRT and Astrill
@@ -9,9 +9,18 @@ ftp://ftp.dd-wrt.com/betas/. Read about the bugs on the builds for the router on
 - Before Astrill installation need to set a param in dd-wrt to ensure installation works fine. Goto Administration->Commands in the webGUI and execute the following commands. Reference: http://svn.dd-wrt.com:8000/ticket/1483
     nvram set no_crossdetect=1 nvram commit
     Run the command and save startup
-- For astrill installation into the router follow https://members.astrill.com/router-setup.php
+- For astrill installation into the router follow https://members.astrill.com/tools/router-set-up
 - Once done reboot router and go to webGUI and Status->My Page->Astrill to configure Astrill
 - Basic config will be to select an appropriate server location under VPN and set to start automatically.Then under site filters set 'Tunnel only International Sites' to use VPN only for geo blocked sites.
+
+NOTE 2018/07/23:
+The above instructions are for setting up DD-WRT and the Astrill VPN applet via a "clean install." For other scenarios, it should be noted that the procedure at https://members.astrill.com/tools/router-set-up (running the eval command via telnet or the DD-WRT Administration->Commands tab) will fail if you are already connected to the VPN (for example, manually using a PPTP/L2TP prior to attempting to install the applet). In that case, the eval command may produce this result:
+    Fetching files... done.
+    sh: eval: line 1: /tmp/astrillvpn: Permission denied
+Inspecting /tmp/astrillvpn with vi via telnet reveals a hidden, pertinent error message:
+    echo "You are already connected to Astrill VPN, perhaps on your router or VPN is running in background 
+    on this device. Please disconnect VPN before you can proceed or try to reboot your device."
+Disconnecting from the VPN and repeating the procedure should yield a successful installation of the applet. In other words: this procedure should work without error if you have DD-WRT already installed as long as you don't ignore the hard-reset mentioned in step 6 above.
 
 From http://en.wikipedia.org/wiki/DD-WRT:
 DD-WRT is a Linux-based firmware for wireless routers and wireless access points. It is compatible with several models of routers and access points. DD-WRT is one of the third-party firmwares, which are designed to replace the original firmware on some commercial routers. Alternative firmware may offer features and functionality sets that differ from the original firmware it is replacing.


### PR DESCRIPTION
- Revised the Astrill router setup URL in the original instructions.
- Added a note about an installation error that could help users stuck in the process is they find these helpful instructions but don't necessarily follow them from step 1—say, they already have DD-WRT on their router and used a manual VPN connection method such as PPTP or L2TP to connect to Astrill's VPN before attempting to install the applet. In that case, there wouldn't necessarily be the need to start from scratch, but the applet install would fail if picking up the proscribed procedure at step 7 or 8.